### PR TITLE
remove trailing whitespace

### DIFF
--- a/easybuild/easyconfigs/h/hwloc/hwloc-1.11.3-GCC-5.2.0.eb
+++ b/easybuild/easyconfigs/h/hwloc/hwloc-1.11.3-GCC-5.2.0.eb
@@ -1,23 +1,23 @@
-easyblock = 'ConfigureMake' 
- 
-name = 'hwloc' 
-version = '1.11.3' 
- 
-homepage = 'http://www.open-mpi.org/projects/hwloc/' 
-description = """The Portable Hardware Locality (hwloc) software package provides a portable abstraction 
-(across OS, versions, architectures, ...) of the hierarchical topology of modern architectures, including 
-NUMA memory nodes, sockets, shared caches, cores and simultaneous multithreading. It also gathers various 
-system attributes such as cache and memory information as well as the locality of I/O devices such as 
-network interfaces, InfiniBand HCAs or GPUs. It primarily aims at helping applications with gathering 
-information about modern computing hardware so as to exploit it accordingly and efficiently.""" 
- 
-toolchain = {'name': 'GCC', 'version': '5.2.0'} 
- 
-source_urls = ['http://www.open-mpi.org/software/hwloc/v%(version_major_minor)s/downloads/'] 
-sources = [SOURCE_TAR_GZ] 
- 
-dependencies = [('numactl', '2.0.11')] 
- 
-configopts = "--enable-libnuma=$EBROOTNUMACTL" 
- 
+easyblock = 'ConfigureMake'
+
+name = 'hwloc'
+version = '1.11.3'
+
+homepage = 'http://www.open-mpi.org/projects/hwloc/'
+description = """The Portable Hardware Locality (hwloc) software package provides a portable abstraction
+(across OS, versions, architectures, ...) of the hierarchical topology of modern architectures, including
+NUMA memory nodes, sockets, shared caches, cores and simultaneous multithreading. It also gathers various
+system attributes such as cache and memory information as well as the locality of I/O devices such as
+network interfaces, InfiniBand HCAs or GPUs. It primarily aims at helping applications with gathering
+information about modern computing hardware so as to exploit it accordingly and efficiently."""
+
+toolchain = {'name': 'GCC', 'version': '5.2.0'}
+
+source_urls = ['http://www.open-mpi.org/software/hwloc/v%(version_major_minor)s/downloads/']
+sources = [SOURCE_TAR_GZ]
+
+dependencies = [('numactl', '2.0.11')]
+
+configopts = "--enable-libnuma=$EBROOTNUMACTL"
+
 moduleclass = 'system'

--- a/easybuild/easyconfigs/n/numactl/numactl-2.0.11-GCC-5.2.0.eb
+++ b/easybuild/easyconfigs/n/numactl/numactl-2.0.11-GCC-5.2.0.eb
@@ -1,23 +1,23 @@
-easyblock = 'ConfigureMake' 
- 
-name = 'numactl' 
-version = '2.0.11' 
- 
-homepage = 'http://oss.sgi.com/projects/libnuma/' 
-description = """The numactl program allows you to run your application program on specific cpu's and memory nodes. 
-It does this by supplying a NUMA memory policy to the operating system before running your program. 
-The libnuma library provides convenient ways for you to add NUMA memory policies into your own program.""" 
- 
+easyblock = 'ConfigureMake'
+
+name = 'numactl'
+version = '2.0.11'
+
+homepage = 'http://oss.sgi.com/projects/libnuma/'
+description = """The numactl program allows you to run your application program on specific cpu's and memory nodes.
+It does this by supplying a NUMA memory policy to the operating system before running your program.
+The libnuma library provides convenient ways for you to add NUMA memory policies into your own program."""
+
 toolchain = {'name': 'GCC', 'version': '5.2.0'}
 
-source_urls = ['ftp://oss.sgi.com/www/projects/libnuma/download/'] 
-sources = [SOURCE_TAR_GZ] 
- 
-checksums = ['d3bc88b7ddb9f06d60898f4816ae9127'] 
- 
-sanity_check_paths = { 
-    'files': ['bin/numactl', 'bin/numastat', 'lib/libnuma.%s' % SHLIB_EXT, 'lib/libnuma.a'], 
-    'dirs': ['share/man', 'include'] 
-} 
- 
+source_urls = ['ftp://oss.sgi.com/www/projects/libnuma/download/']
+sources = [SOURCE_TAR_GZ]
+
+checksums = ['d3bc88b7ddb9f06d60898f4816ae9127']
+
+sanity_check_paths = {
+    'files': ['bin/numactl', 'bin/numastat', 'lib/libnuma.%s' % SHLIB_EXT, 'lib/libnuma.a'],
+    'dirs': ['share/man', 'include']
+}
+
 moduleclass = 'tools'


### PR DESCRIPTION
for some reason, there's a lot of trailing whitespace in the easyconfigs you contributed via https://github.com/hpcugent/easybuild-easyconfigs/pull/3449, any idea why?

This is annoying since it screws around with our review process (`eb --review-pr`).

This PR cleans up that trailing whitespace, please include this in your branch?