### PR TITLE
fix minor style issues (indent/order/long lines)

### DIFF
--- a/easybuild/easyconfigs/a/ABINIT/ABINIT-7.6.2-foss-2015a.eb
+++ b/easybuild/easyconfigs/a/ABINIT/ABINIT-7.6.2-foss-2015a.eb
@@ -4,12 +4,23 @@ name = 'ABINIT'
 version = '7.6.2'
 
 homepage = 'http://www.abinit.org/'
-description = """Abinit is a plane wave pseudopotential code for doing condensed phase electronic structure calculations using DFT."""
+description = """Abinit is a plane wave pseudopotential code for doing condensed phase electronic
+ structure calculations using DFT."""
 
 toolchain = {'name': 'foss', 'version': '2015a'}
 
 source_urls = ['http://ftp.abinit.org/']
 sources = [SOURCELOWER_TAR_GZ]
+
+patches = [
+    'ABINIT-%(version)s_named-constant.patch',
+    'ABINIT-%(version)s_odamix.patch',
+]
+
+dependencies = [
+    ('netCDF', '4.3.2'),
+    ('netCDF-Fortran', '4.4.0'),
+]
 
 configopts = '--enable-mpi --with-mpi-prefix="$EBROOTOPENMPI" --enable-fallbacks '
 configopts += '--with-netcdf-incs="-I$EBROOTNETCDF/include -I$EBROOTNETCDFMINFORTRAN/include" '
@@ -17,15 +28,9 @@ configopts += '--with-netcdf-libs="-L$EBROOTNETCDF/lib64 -lnetcdf -L$EBROOTNETCD
 configopts += '--with-fft-libs="-L$EBROOTFFTW/lib -lfftw3 -lfftw3f" --with-fft-flavor=fftw3 '
 configopts += '--with-trio-flavor=netcdf+etsf_io --with-dft-flavor=libxc --enable-gw-dpc'
 
-patches = ['ABINIT-%(version)s_named-constant.patch',
-           'ABINIT-%(version)s_odamix.patch',]
-
-dependencies = [
-    ('netCDF', '4.3.2'),
-    ('netCDF-Fortran', '4.4.0'),]
-
 sanity_check_paths = {
     'files': ["bin/abinit"],
-    'dirs': []}
+    'dirs': [],
+}
 
 moduleclass = 'chem'


### PR DESCRIPTION
for https://github.com/hpcugent/easybuild-easyconfigs/pull/3450

@AFCJamie this may sound picky, but we try to maintain a specific 'code' style in easyconfigs, which make it very easy to compare them and 'parse' them for humans

this involves avoiding too long lines (should be less than 120 characters), sticking to a specific style of indenting (usually one list element per line), and also following a logic order of parameters (that has been defined loosely over time)

some of this is specified at http://easybuild.readthedocs.io/en/latest/Code_style.html, but that's unfortunately an incomplete specification; we're working on automating the style review of easyconfigs to make this more strictly enforced, clearer and more consistent (cfr. https://github.com/hpcugent/easybuild-framework/pull/1618)

this patch solves a couple of minor style issues in your easyconfig, please review/merge to update your PR https://github.com/hpcugent/easybuild-easyconfigs/pull/3450 ?